### PR TITLE
chore(README): add hyperlinks to badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,22 +4,38 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/github/issues/NotCosmo/Vortex-V2?style=flat-square" alt="issues-shield">
-  <img src="https://img.shields.io/github/issues-pr/NotCosmo/Vortex-V2?style=flat-square" alt="prs-shield">
-  <img src="https://img.shields.io/github/contributors/NotCosmo/Vortex-V2?style=flat-square" alt="contributors-shield">
-  <img src="https://img.shields.io/github/commit-activity/m/NotCosmo/Vortex-V2?style=flat-square" alt="commit-activity-shield">
+  <a href="https://github.com/NotCosmo/Vortex-V2/issues">
+    <img src="https://img.shields.io/github/issues/NotCosmo/Vortex-V2?style=flat-square" alt="issues-shield">
+  </a>
+  <a href="https://github.com/NotCosmo/Vortex-V2/pulls">
+    <img src="https://img.shields.io/github/issues-pr/NotCosmo/Vortex-V2?style=flat-square" alt="prs-shield">
+  </a>
+  <a href="https://github.com/NotCosmo/Vortex-V2/graphs/contributors">
+    <img src="https://img.shields.io/github/contributors/NotCosmo/Vortex-V2?style=flat-square" alt="contributors-shield">
+  </a>
+  <a href="https://github.com/NotCosmo/Vortex-V2/commits/main">
+    <img src="https://img.shields.io/github/commit-activity/m/NotCosmo/Vortex-V2?style=flat-square" alt="commit-activity-shield">
+  </a>
   <img src="https://img.shields.io/github/repo-size/NotCosmo/Vortex-V2?style=flat-square" alt="repo-size-shield">
 </p>
 
 <p align="center">
   <img src="https://img.shields.io/github/license/NotCosmo/Vortex-V2?style=flat-square" alt="license-shield">
-  <img src="https://img.shields.io/badge/code%20style-black-black?style=flat-square" alt="codestyle-black-shield">
-  <img src="https://img.shields.io/github/stars/NotCosmo/Vortex-V2?style=flat-square" alt="stars-shield">
-  <img src="https://img.shields.io/github/forks/NotCosmo/Vortex-V2?style=flat-square" alt="forks-shield">
+  <a href="https://github.com/psf/black">
+    <img src="https://img.shields.io/badge/code%20style-black-black?style=flat-square" alt="codestyle-black-shield">
+  </a>
+  <a href="https://github.com/NotCosmo/Vortex-V2/stargazers">
+    <img src="https://img.shields.io/github/stars/NotCosmo/Vortex-V2?style=flat-square" alt="stars-shield">
+  </a>
+  <a href="https://github.com/NotCosmo/Vortex-V2/network/members">
+    <img src="https://img.shields.io/github/forks/NotCosmo/Vortex-V2?style=flat-square" alt="forks-shield">
+  </a>
 </p>
 
 <p align="center">
-  <img src="https://custom-icon-badges.herokuapp.com/badge/-Made%20with%20Nextcord-0d1620?logo=nextcord">
+  <a href="https://nextcord.dev">
+    <img src="https://custom-icon-badges.herokuapp.com/badge/-Made%20with%20Nextcord-0d1620?logo=nextcord">
+  </a>
 </p>
 
 


### PR DESCRIPTION
## Summary

This adds hyperlinks to badges in the README files. This is very useless, but I did it anyway :^)

NOTE: I could add a redirect to the `repo size` badge, I think that'd just redirect to the repository it's self, but I found that kind of a useless redirect but I'm open to opinions.
NOTE 2: The license badge is also (temporarily) empty because this repository currently doesn't have a license(don't know why).

## Checklist:

- [ ] This PR follows style guidelines (black, isort) of this project.
- [ ] This PR has been tested.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new.
- [x] This PR is **not** a code change (e.g. README, typos, ...)
